### PR TITLE
Enclose Gemfiles in the layer package

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -77,6 +77,29 @@ usage: |-
   }
   ```
 
+  ### Example on Ruby Gem layer
+
+  ```hcl
+  module "layer" {
+    source = "git::https://github.com/enter-at/terraform-aws-lambda-layer.git?ref=main"
+    layer_name   = "dependencies"
+    source       = "."
+    package_file = "Gemfile"
+    compatible_runtimes = ["ruby2.7"]
+  }
+  ```
+
+  Note the following
+
+  * The package includes the following directory structure ruby/*ruby\_version*
+  * The root directory contains Gemfile/Gemfile.lock. These are included for referential integrity
+    You will probably wanto to copy these on startup of your `lambda_function`
+
+  ```ruby
+  # Before any require
+  system("cp /opt/Gemfile.* .") unless File.exist?('Gemfile.lock')
+  ```
+
 include:
   - "docs/terraform.md"
 

--- a/README.yaml
+++ b/README.yaml
@@ -91,13 +91,14 @@ usage: |-
 
   Note the following
 
-  * The package includes the following directory structure ruby/*ruby\_version*
-  * The root directory contains Gemfile/Gemfile.lock. These are included for referential integrity
-    You will probably wanto to copy these on startup of your `lambda_function`
+  * The package includes the following directory structure ruby/*ruby\_version*/...
+  * The ruby directory contains Gemfile/Gemfile.lock. These are included for referential integrity
+    You will may want to symlink these together with your `lambda_function`
 
-  ```ruby
-  # Before any require
-  system("cp /opt/Gemfile.* .") unless File.exist?('Gemfile.lock')
+  ```sh
+  # In your script for packing lambda function
+  ln -sf /opt/ruby/Gemfile Gemfile
+  ln -sf /opt/ruby/Gemfile.lock Gemfile.lock
   ```
 
 include:

--- a/build.sh
+++ b/build.sh
@@ -70,6 +70,8 @@ install_gem_dependencies() {
   bundle config --local deployment true
   bundle config --local without test:development
   bundle install --jobs 4
+  rm -rf .bundle # remove .bundle directory, as it is unwanted when not in deployment mode
+  cp Gemfile Gemfile.lock "$DIST_DIR" # Only way to ensure referential integrity
   popd >/dev/null || exit
 }
 

--- a/build.sh
+++ b/build.sh
@@ -71,7 +71,7 @@ install_gem_dependencies() {
   bundle config --local without test:development
   bundle install --jobs 4
   rm -rf .bundle # remove .bundle directory, as it is unwanted when not in deployment mode
-  cp Gemfile Gemfile.lock "$DIST_DIR" # Only way to ensure referential integrity
+  cp Gemfile Gemfile.lock "$DIST_DIR/ruby" # Only way to ensure referential integrity
   popd >/dev/null || exit
 }
 


### PR DESCRIPTION
**Rationale**

There might be discrepancy between the `lambda_function` reference to gems and the layer reference.
Best way to deal with this discrepancy is to use the Gemfile/Gemfile.lock files of the layer, and not the ones used with the lambda_function. 

Most relevant is this when referencing private repository gems which is thighed to commit reference. (Difficult to synchronize between repositories and build processes).